### PR TITLE
Feedback from Alex

### DIFF
--- a/workshop/01_introduction/instructions.md
+++ b/workshop/01_introduction/instructions.md
@@ -30,10 +30,10 @@ To start with, `ExampleWidget` consists of three similar `ElevatedButton` widget
 ```dart
 Column(
   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-  children: [
-    ElevatedButton(child: Text('first'), onPressed: () {}),
-    ElevatedButton(child: Text('second'), onPressed: () {}),
-    ElevatedButton(child: Text('third'), onPressed: () {}),
+  children: <Widget>[
+    ElevatedButton(child: const Text('first'), onPressed: () {}),
+    ElevatedButton(child: const Text('second'), onPressed: () {}),
+    ElevatedButton(child: const Text('third'), onPressed: () {}),
   ],
 )
 ```

--- a/workshop/01_introduction/snippet.dart
+++ b/workshop/01_introduction/snippet.dart
@@ -1,15 +1,15 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       debugShowCheckedModeBanner: false,
       home: ExamplePage(),
     );
@@ -17,12 +17,19 @@ class ExampleApp extends StatelessWidget {
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
       body: Padding(
         padding: EdgeInsets.all(20.0),
@@ -32,7 +39,7 @@ class ExamplePage extends StatelessWidget {
           // Tip: Place your cursor over the ExampleWidget text below and hit
           // alt + enter on Windows/Linux or option + return on Mac. Then,
           // select "Wrap with widget..." from the dropdown menu that appears.
-          child: ExampleWidget(),
+          child: const ExampleWidget(),
         ),
       ),
     );
@@ -40,14 +47,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('first'), onPressed: () {}),
-        ElevatedButton(child: Text('second'), onPressed: () {}),
-        ElevatedButton(child: Text('third'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('first'), onPressed: () {}),
+        ElevatedButton(child: const Text('second'), onPressed: () {}),
+        ElevatedButton(child: const Text('third'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/01_introduction/solution.dart
+++ b/workshop/01_introduction/solution.dart
@@ -1,15 +1,15 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       debugShowCheckedModeBanner: false,
       home: ExamplePage(),
     );
@@ -17,15 +17,22 @@ class ExampleApp extends StatelessWidget {
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
       body: Padding(
-        padding: EdgeInsets.all(20.0),
+        padding: const EdgeInsets.all(20.0),
         child: Center(
           child: Theme(
             data: ThemeData(
@@ -36,7 +43,7 @@ class ExamplePage extends StatelessWidget {
                 ),
               ),
             ),
-            child: ExampleWidget(),
+            child: const ExampleWidget(),
           ),
         ),
       ),
@@ -45,14 +52,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('first'), onPressed: () {}),
-        ElevatedButton(child: Text('second'), onPressed: () {}),
-        ElevatedButton(child: Text('third'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('first'), onPressed: () {}),
+        ElevatedButton(child: const Text('second'), onPressed: () {}),
+        ElevatedButton(child: const Text('third'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/02.1_themedata/instructions.md
+++ b/workshop/02.1_themedata/instructions.md
@@ -14,7 +14,7 @@ Theme(
       ),
     ),
   ),
-  child: ExampleWidget(),
+  child: const ExampleWidget(),
 )
 ```
 

--- a/workshop/02.1_themedata/snippet.dart
+++ b/workshop/02.1_themedata/snippet.dart
@@ -1,15 +1,15 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       debugShowCheckedModeBanner: false,
       home: ExamplePage(),
     );
@@ -17,15 +17,22 @@ class ExampleApp extends StatelessWidget {
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
       body: Padding(
-        padding: EdgeInsets.all(20.0),
+        padding: const EdgeInsets.all(20.0),
         child: Center(
           child: Theme(
             data: ThemeData(
@@ -37,7 +44,7 @@ class ExamplePage extends StatelessWidget {
                 ),
               ),
             ),
-            child: ExampleWidget(),
+            child: const ExampleWidget(),
           ),
         ),
       ),
@@ -46,14 +53,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('first'), onPressed: () {}),
-        ElevatedButton(child: Text('second'), onPressed: () {}),
-        ElevatedButton(child: Text('third'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('first'), onPressed: () {}),
+        ElevatedButton(child: const Text('second'), onPressed: () {}),
+        ElevatedButton(child: const Text('third'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/02.1_themedata/solution.dart
+++ b/workshop/02.1_themedata/solution.dart
@@ -1,15 +1,15 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       debugShowCheckedModeBanner: false,
       home: ExamplePage(),
     );
@@ -17,15 +17,22 @@ class ExampleApp extends StatelessWidget {
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
       body: Padding(
-        padding: EdgeInsets.all(20.0),
+        padding: const EdgeInsets.all(20.0),
         child: Center(
           child: Theme(
             data: ThemeData(
@@ -37,7 +44,7 @@ class ExamplePage extends StatelessWidget {
                 ),
               ),
             ),
-            child: ExampleWidget(),
+            child: const ExampleWidget(),
           ),
         ),
       ),
@@ -46,14 +53,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('first'), onPressed: () {}),
-        ElevatedButton(child: Text('second'), onPressed: () {}),
-        ElevatedButton(child: Text('third'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('first'), onPressed: () {}),
+        ElevatedButton(child: const Text('second'), onPressed: () {}),
+        ElevatedButton(child: const Text('third'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/02.2_themedata/instructions.md
+++ b/workshop/02.2_themedata/instructions.md
@@ -2,7 +2,7 @@
 
 In the previous workshop steps the `ThemeData` configuration was applied only to a part of the widget tree wrapped with the `Theme` widget. Other parts of the screen or other screens were not styled in the same way. 
 
-To make the styling consistent across the entire application, the  `MaterialApp` widget exposes a special `theme` field of `ThemeData` type. When set, the given `ThemeData` configuration is applied to all application screens:
+To make the styling consistent across the entire application, the `MaterialApp` widget exposes a special `theme` field of `ThemeData` type. When set, the given `ThemeData` configuration is applied to all application screens:
 
 ```dart
 MaterialApp(
@@ -10,11 +10,11 @@ MaterialApp(
     colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
     elevatedButtonTheme: ElevatedButtonThemeData(...),
   ),
-  home: ExamplePage(),
+  home: const ExamplePage(),
 )
 ```
 
-In fact, under the hood, the `MaterialApp` widget passes the given `theme` value to the inner `Theme` widget, which wraps all application screens.
+In fact, under the hood, the `MaterialApp` widget passes the given `theme` value to the inner `Theme` widget, which wraps at the top of the application.
 
 It's worth mentioning that if no `theme` value is provided to `MaterialApp` widget, the default `ThemeData.light()` is used. That is why the three buttons were blue without any customization.
 

--- a/workshop/02.2_themedata/snippet.dart
+++ b/workshop/02.2_themedata/snippet.dart
@@ -1,33 +1,42 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
+// ignore_for_file: prefer_const_constructors
 
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       // TODO 1: Provide theme field value
       // TODO 3: Provide darkTheme field value, specify themeMode
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
       body: Padding(
-        padding: EdgeInsets.all(20.0),
+        padding: const EdgeInsets.all(20.0),
         child: Center(
           // TODO 2: Remove the Theme widget
 
@@ -53,14 +62,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('first'), onPressed: () {}),
-        ElevatedButton(child: Text('second'), onPressed: () {}),
-        ElevatedButton(child: Text('third'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('first'), onPressed: () {}),
+        ElevatedButton(child: const Text('second'), onPressed: () {}),
+        ElevatedButton(child: const Text('third'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/02.2_themedata/solution.dart
+++ b/workshop/02.2_themedata/solution.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -22,20 +22,27 @@ class ExampleApp extends StatelessWidget {
       ),
       darkTheme: ThemeData.dark(),
       themeMode: ThemeMode.light,
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -46,14 +53,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('first'), onPressed: () {}),
-        ElevatedButton(child: Text('second'), onPressed: () {}),
-        ElevatedButton(child: Text('third'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('first'), onPressed: () {}),
+        ElevatedButton(child: const Text('second'), onPressed: () {}),
+        ElevatedButton(child: const Text('third'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/03.1_texts_icons/instructions.md
+++ b/workshop/03.1_texts_icons/instructions.md
@@ -31,7 +31,7 @@ IconTheme(
     size: 36.0,
     opacity: 0.5,
   ),
-  child: Icon(Icons.email),
+  child: const Icon(Icons.email),
 )
 ```
 
@@ -58,7 +58,7 @@ With this change, all application icons would become lime and half-transparent.
 
 ```dart
 IconButton(
-  icon: Icon(Icons.language), 
+  icon: const Icon(Icons.language), 
   onPressed: () {},
 )
 ```
@@ -69,9 +69,9 @@ By default, customizations of the global theme `iconTheme` field also affect `Ic
 
 ```dart
 AppBar(
-  actions: [
+  actions: <Widget>[
     IconButton(
-      icon: Icon(Icons.account_circle), 
+      icon: const Icon(Icons.account_circle), 
       onPressed: () {}
     ),
   ],

--- a/workshop/03.1_texts_icons/snippet.dart
+++ b/workshop/03.1_texts_icons/snippet.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -15,20 +15,27 @@ class ExampleApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
         // TODO 1: Provide iconTheme field value
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -39,13 +46,15 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        Icon(Icons.email),
-        IconButton(icon: Icon(Icons.language), onPressed: () {}),
+      children: <Widget>[
+        const Icon(Icons.email),
+        IconButton(icon: const Icon(Icons.language), onPressed: () {}),
       ],
     );
   }

--- a/workshop/03.1_texts_icons/solution.dart
+++ b/workshop/03.1_texts_icons/solution.dart
@@ -1,38 +1,45 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
-        iconTheme: IconThemeData(
+        iconTheme: const IconThemeData(
           color: Colors.lime,
           size: 36.0,
           opacity: 0.5,
         ),
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -43,13 +50,15 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        Icon(Icons.email),
-        IconButton(icon: Icon(Icons.language), onPressed: () {}),
+      children: <Widget>[
+        const Icon(Icons.email),
+        IconButton(icon: const Icon(Icons.language), onPressed: () {}),
       ],
     );
   }

--- a/workshop/03.2_texts_icons/instructions.md
+++ b/workshop/03.2_texts_icons/instructions.md
@@ -9,12 +9,11 @@ Typically, applications use a variety of text styles. Thus, `Text` widgets are u
 ```dart
 Text(
   'example',
-  style: TextStyle(
+  style: const TextStyle(
     color: Colors.red,
     fontSize: 18.0,
     fontWeight: FontWeight.bold,
     letterSpacing: 0.8,
-    ...
   ),
 )
 ```
@@ -65,13 +64,14 @@ These should be used as a starting point and further customized with `copyWith` 
 
 ```dart
 ThemeData(
-  textTheme: Typography().black
+  textTheme: Typography()
+    .black
     .apply(
       displayColor: Colors.greenAccent,
       bodyColor: Colors.green,
     )
     .copyWith(
-      displayLarge: TextStyle(
+      displayLarge: const TextStyle(
         color: Colors.lightGreen,
         fontSize: 18.0,
         fontWeight: FontWeight.bold,

--- a/workshop/03.2_texts_icons/snippet.dart
+++ b/workshop/03.2_texts_icons/snippet.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -16,20 +16,27 @@ class ExampleApp extends StatelessWidget {
         // TODO 1: Set textTheme field value
         // TODO 2: Use .apply and .copyWith methods
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -40,15 +47,26 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        Text('displayLarge', style: Theme.of(context).textTheme.displayLarge),
-        Text('explicit bodyMedium', style: Theme.of(context).textTheme.bodyMedium),
-        Text('implicit bodyMedium'),
-        Text('labelSmall', style: Theme.of(context).textTheme.labelSmall),
+      children: <Widget>[
+        Text(
+          'displayLarge',
+          style: Theme.of(context).textTheme.displayLarge,
+        ),
+        Text(
+          'explicit bodyMedium',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const Text('implicit bodyMedium'),
+        Text(
+          'labelSmall',
+          style: Theme.of(context).textTheme.labelSmall,
+        ),
       ],
     );
   }

--- a/workshop/03.2_texts_icons/solution.dart
+++ b/workshop/03.2_texts_icons/solution.dart
@@ -1,25 +1,26 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
-        textTheme: Typography().black
+        textTheme: Typography()
+            .black
             .apply(
               displayColor: Colors.greenAccent,
               bodyColor: Colors.green,
             )
             .copyWith(
-              displayLarge: TextStyle(
+              displayLarge: const TextStyle(
                 color: Colors.lightGreen,
                 fontSize: 18.0,
                 fontWeight: FontWeight.bold,
@@ -27,20 +28,27 @@ class ExampleApp extends StatelessWidget {
               ),
             ),
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -51,15 +59,26 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        Text('displayLarge', style: Theme.of(context).textTheme.displayLarge),
-        Text('explicit bodyMedium', style: Theme.of(context).textTheme.bodyMedium),
-        Text('implicit bodyMedium'),
-        Text('labelSmall', style: Theme.of(context).textTheme.labelSmall),
+      children: <Widget>[
+        Text(
+          'displayLarge',
+          style: Theme.of(context).textTheme.displayLarge,
+        ),
+        Text(
+          'explicit bodyMedium',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        const Text('implicit bodyMedium'),
+        Text(
+          'labelSmall',
+          style: Theme.of(context).textTheme.labelSmall,
+        ),
       ],
     );
   }

--- a/workshop/04.1_buttons/instructions.md
+++ b/workshop/04.1_buttons/instructions.md
@@ -53,13 +53,17 @@ Let's say the button should have an overlay of different shades of green when ho
 
 ```dart
 ButtonStyle(
-  overlayColor: MaterialStateProperty.resolveWith((states) {
-    if (states.contains(MaterialState.hovered))
-      return Colors.greenAccent;
-    if (states.contains(MaterialState.pressed))
-      return Colors.lightGreenAccent;
-    return null;
-  }),
+  overlayColor: MaterialStateProperty.resolveWith(
+    (Set<MaterialState> states) {
+      if (states.contains(MaterialState.hovered)) {
+        return Colors.greenAccent;
+      }
+      if (states.contains(MaterialState.pressed)) {
+        return Colors.lightGreenAccent;
+      }
+      return null;
+    },
+  ),
 )
 ```
 
@@ -78,10 +82,11 @@ In the previous step of this workshop, it was mentioned that `ElevatedButton`, `
 
 ```dart
 ButtonStyle(
-  textStyle: MaterialStateProperty.resolveWith((states) => 
-    states.contains(MaterialState.pressed)
-      ? TextStyle(fontWeight: FontWeight.bold)
-      : null
+  textStyle: MaterialStateProperty.resolveWith(
+    (Set<MaterialState> states) =>
+        states.contains(MaterialState.pressed)
+            ? const TextStyle(fontWeight: FontWeight.bold)
+            : null,
   ),
 )
 ```

--- a/workshop/04.1_buttons/snippet.dart
+++ b/workshop/04.1_buttons/snippet.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -15,20 +15,27 @@ class ExampleApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
         // TODO 1: Provide elevatedButtonTheme field value
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -39,14 +46,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('ElevatedButton'), onPressed: () {}),
-        OutlinedButton(child: Text('OutlinedButton'), onPressed: () {}),
-        TextButton(child: Text('TextButton'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('ElevatedButton'), onPressed: () {}),
+        OutlinedButton(child: const Text('OutlinedButton'), onPressed: () {}),
+        TextButton(child: const Text('TextButton'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/04.1_buttons/solution.dart
+++ b/workshop/04.1_buttons/solution.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -17,35 +17,47 @@ class ExampleApp extends StatelessWidget {
           style: ButtonStyle(
             backgroundColor: MaterialStateProperty.all(Colors.lime),
             foregroundColor: MaterialStateProperty.all(Colors.blue),
-            overlayColor: MaterialStateProperty.resolveWith((states) {
-              if (states.contains(MaterialState.hovered))
-                return Colors.greenAccent;
-              if (states.contains(MaterialState.pressed))
-                return Colors.lightGreenAccent;
-              return null;
-            }),
-            textStyle: MaterialStateProperty.resolveWith((states) =>
-              states.contains(MaterialState.pressed)
-                ? TextStyle(fontWeight: FontWeight.bold)
-                : null
+            overlayColor: MaterialStateProperty.resolveWith(
+              (Set<MaterialState> states) {
+                if (states.contains(MaterialState.hovered)) {
+                  return Colors.greenAccent;
+                }
+                if (states.contains(MaterialState.pressed)) {
+                  return Colors.lightGreenAccent;
+                }
+                return null;
+              },
+            ),
+            textStyle: MaterialStateProperty.resolveWith(
+              (Set<MaterialState> states) =>
+                  states.contains(MaterialState.pressed)
+                      ? const TextStyle(fontWeight: FontWeight.bold)
+                      : null,
             ),
           ),
         ),
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -56,14 +68,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('ElevatedButton'), onPressed: () {}),
-        OutlinedButton(child: Text('OutlinedButton'), onPressed: () {}),
-        TextButton(child: Text('TextButton'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('ElevatedButton'), onPressed: () {}),
+        OutlinedButton(child: const Text('OutlinedButton'), onPressed: () {}),
+        TextButton(child: const Text('TextButton'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/04.2_buttons/instructions.md
+++ b/workshop/04.2_buttons/instructions.md
@@ -23,18 +23,23 @@ And similarly, a `ButtonStyle` object can be created with the default `ButtonSty
 ```dart
 ButtonStyle(
   foregroundColor: MaterialStateProperty.all(Colors.green),
-  side: MaterialStateProperty.all(BorderSide(color: Colors.green, width: 2)),
+  side: MaterialStateProperty.all(
+    const BorderSide(color: Colors.green, width: 2),
+  ),
   overlayColor: MaterialStateProperty.resolveWith((states) {
-    if (states.contains(MaterialState.hovered))
+    if (states.contains(MaterialState.hovered)) {
       return Colors.greenAccent;
-    if (states.contains(MaterialState.pressed))
+    }
+    if (states.contains(MaterialState.pressed)) {
       return Colors.lightGreenAccent;
+    }
     return null;
   }),
-  textStyle: MaterialStateProperty.resolveWith((states) =>
-    states.contains(MaterialState.pressed)
-      ? TextStyle(fontWeight: FontWeight.bold)
-      : null
+  textStyle: MaterialStateProperty.resolveWith(
+    (Set<MaterialState> states) =>
+        states.contains(MaterialState.pressed)
+            ? const TextStyle(fontWeight: FontWeight.bold)
+            : null,
   ),
 ),
 ```
@@ -47,21 +52,26 @@ Have you noticed that in the code snippet above the `overlayColor` and `textStyl
 class ButtonOverlayColor implements MaterialStateProperty<Color?> {
   @override
   Color? resolve(Set<MaterialState> states) {
-    if (states.contains(MaterialState.hovered)) 
+    if (states.contains(MaterialState.hovered)) {
       return Colors.greenAccent;
-    if (states.contains(MaterialState.pressed)) 
+    }
+    if (states.contains(MaterialState.pressed)) {
       return Colors.lightGreenAccent;
+    }
     return null;
   }
 }
 ```
+
 ```dart
 class ButtonTextStyle implements MaterialStateProperty<TextStyle?> {
   @override
-  TextStyle? resolve(Set<MaterialState> states) =>
-    states.contains(MaterialState.pressed)
-      ? TextStyle(fontWeight: FontWeight.bold)
-      : null;
+  TextStyle? resolve(Set<MaterialState> states) {
+    if (states.contains(MaterialState.pressed)) {
+      return const TextStyle(fontWeight: FontWeight.bold);
+    }
+    return null;
+  }
 }
 ```
 

--- a/workshop/04.2_buttons/snippet.dart
+++ b/workshop/04.2_buttons/snippet.dart
@@ -1,14 +1,14 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 // TODO 1: Declare ButtonOverlayColor and ButtonTextStyle classes
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -20,39 +20,51 @@ class ExampleApp extends StatelessWidget {
             backgroundColor: MaterialStateProperty.all(Colors.lime),
             foregroundColor: MaterialStateProperty.all(Colors.blue),
             // TODO 2: Replace overlayColor field value with an instance of ButtonOverlayColor
-            overlayColor: MaterialStateProperty.resolveWith((states) {
-              if (states.contains(MaterialState.hovered))
-                return Colors.greenAccent;
-              if (states.contains(MaterialState.pressed))
-                return Colors.lightGreenAccent;
-              return null;
-            }),
+            overlayColor: MaterialStateProperty.resolveWith(
+              (Set<MaterialState> states) {
+                if (states.contains(MaterialState.hovered)) {
+                  return Colors.greenAccent;
+                }
+                if (states.contains(MaterialState.pressed)) {
+                  return Colors.lightGreenAccent;
+                }
+                return null;
+              },
+            ),
             // TODO 2: Replace textStyle field value with an instance of ButtonTextStyle
-            textStyle: MaterialStateProperty.resolveWith((states) =>
-              states.contains(MaterialState.pressed)
-                ? TextStyle(fontWeight: FontWeight.bold)
-                : null
+            textStyle: MaterialStateProperty.resolveWith(
+              (Set<MaterialState> states) =>
+                  states.contains(MaterialState.pressed)
+                      ? const TextStyle(fontWeight: FontWeight.bold)
+                      : null,
             ),
           ),
         ),
         // TODO 3: Provide outlinedButtonTheme field value
         // TODO 4: Provide textButtonTheme field value
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
       body: Padding(
-        padding: EdgeInsets.all(20.0),
+        padding: const EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
         ),
@@ -66,10 +78,10 @@ class ExampleWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('ElevatedButton'), onPressed: () {}),
-        OutlinedButton(child: Text('OutlinedButton'), onPressed: () {}),
-        TextButton(child: Text('TextButton'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('ElevatedButton'), onPressed: () {}),
+        OutlinedButton(child: const Text('OutlinedButton'), onPressed: () {}),
+        TextButton(child: const Text('TextButton'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/04.2_buttons/solution.dart
+++ b/workshop/04.2_buttons/solution.dart
@@ -1,31 +1,35 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ButtonOverlayColor implements MaterialStateProperty<Color?> {
   @override
   Color? resolve(Set<MaterialState> states) {
-    if (states.contains(MaterialState.hovered))
+    if (states.contains(MaterialState.hovered)) {
       return Colors.greenAccent;
-    if (states.contains(MaterialState.pressed))
+    }
+    if (states.contains(MaterialState.pressed)) {
       return Colors.lightGreenAccent;
+    }
     return null;
   }
 }
 
 class ButtonTextStyle implements MaterialStateProperty<TextStyle?> {
   @override
-  TextStyle? resolve(Set<MaterialState> states) =>
-    states.contains(MaterialState.pressed)
-      ? TextStyle(fontWeight: FontWeight.bold)
-      : null;
+  TextStyle? resolve(Set<MaterialState> states) {
+    if (states.contains(MaterialState.pressed)) {
+      return const TextStyle(fontWeight: FontWeight.bold);
+    }
+    return null;
+  }
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -43,7 +47,9 @@ class ExampleApp extends StatelessWidget {
         outlinedButtonTheme: OutlinedButtonThemeData(
           style: ButtonStyle(
             foregroundColor: MaterialStateProperty.all(Colors.green),
-            side: MaterialStateProperty.all(BorderSide(color: Colors.green, width: 2)),
+            side: MaterialStateProperty.all(
+              const BorderSide(color: Colors.green, width: 2),
+            ),
             overlayColor: ButtonOverlayColor(),
             textStyle: ButtonTextStyle(),
           ),
@@ -54,20 +60,27 @@ class ExampleApp extends StatelessWidget {
           ),
         ),
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -78,14 +91,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
-        ElevatedButton(child: Text('ElevatedButton'), onPressed: () {}),
-        OutlinedButton(child: Text('OutlinedButton'), onPressed: () {}),
-        TextButton(child: Text('TextButton'), onPressed: () {}),
+      children: <Widget>[
+        ElevatedButton(child: const Text('ElevatedButton'), onPressed: () {}),
+        OutlinedButton(child: const Text('OutlinedButton'), onPressed: () {}),
+        TextButton(child: const Text('TextButton'), onPressed: () {}),
       ],
     );
   }

--- a/workshop/05_inputs/instructions.md
+++ b/workshop/05_inputs/instructions.md
@@ -19,14 +19,14 @@ The `InputDecorationTheme` class has about 30 fields dedicated to different aspe
 
 ```dart
 InputDecorationTheme(
-  errorStyle: TextStyle(
+  errorStyle: const TextStyle(
     fontStyle: FontStyle.italic,
   ),
-  floatingLabelStyle: TextStyle(
+  floatingLabelStyle: const TextStyle(
     fontWeight: FontWeight.bold,
     color: Colors.lightGreen,
   ),
-  hintStyle: TextStyle(
+  hintStyle: const TextStyle(
     fontStyle: FontStyle.italic,
     fontSize: 14.0,
   ),
@@ -98,16 +98,24 @@ This means that to repeat the borders styling above, instead of providing five d
 
 ```dart
 InputDecorationTheme(
-  border: MaterialStateOutlineInputBorder.resolveWith((states) {
-    final isFocused = states.contains(MaterialState.focused);
-    final isDisabled = states.contains(MaterialState.disabled);
-    final hasError = states.contains(MaterialState.error);
+  border: MaterialStateOutlineInputBorder.resolveWith(
+    (Set<MaterialState> states) {
+      final bool isFocused = states.contains(MaterialState.focused);
+      final bool isDisabled = states.contains(MaterialState.disabled);
+      final bool hasError = states.contains(MaterialState.error);
 
-    final color = isDisabled ? Colors.grey : hasError ? Colors.red : Colors.lightGreen;
-    final width = isFocused ? 2.0 : 1.0;
-    
-    return OutlineInputBorder(borderSide: BorderSide(color: color, width: width));
-  }),
+      final MaterialColor color = isDisabled
+          ? Colors.grey
+          : hasError
+              ? Colors.red
+              : Colors.lightGreen;
+      final double width = isFocused ? 2.0 : 1.0;
+
+      return OutlineInputBorder(
+        borderSide: BorderSide(color: color, width: width),
+      );
+    },
+  ),
 )
 ```
 

--- a/workshop/05_inputs/snippet.dart
+++ b/workshop/05_inputs/snippet.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -16,20 +16,27 @@ class ExampleApp extends StatelessWidget {
         // TODO 1: Provide inputDecorationTheme field value
         // TODO 2: Provide textSelectionTheme field value
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -40,11 +47,13 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
+      children: const <Widget>[
         TextField(
           decoration: InputDecoration(
             hintText: 'enabled',

--- a/workshop/05_inputs/solution.dart
+++ b/workshop/05_inputs/solution.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -14,49 +14,62 @@ class ExampleApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
         inputDecorationTheme: InputDecorationTheme(
-          errorStyle: TextStyle(
-            fontStyle: FontStyle.italic,
-          ),
-          floatingLabelStyle: TextStyle(
+          errorStyle: const TextStyle(fontStyle: FontStyle.italic),
+          floatingLabelStyle: const TextStyle(
             fontWeight: FontWeight.bold,
             color: Colors.lightGreen,
           ),
-          hintStyle: TextStyle(
+          hintStyle: const TextStyle(
             fontStyle: FontStyle.italic,
             fontSize: 14.0,
           ),
           suffixIconColor: Colors.greenAccent,
-          border: MaterialStateOutlineInputBorder.resolveWith((states) {
-            final isFocused = states.contains(MaterialState.focused);
-            final isDisabled = states.contains(MaterialState.disabled);
-            final hasError = states.contains(MaterialState.error);
+          border: MaterialStateOutlineInputBorder.resolveWith(
+            (Set<MaterialState> states) {
+              final bool isFocused = states.contains(MaterialState.focused);
+              final bool isDisabled = states.contains(MaterialState.disabled);
+              final bool hasError = states.contains(MaterialState.error);
 
-            final color = isDisabled ? Colors.grey : hasError ? Colors.red : Colors.lightGreen;
-            final width = isFocused ? 2.0 : 1.0;
+              final MaterialColor color = isDisabled
+                  ? Colors.grey
+                  : hasError
+                      ? Colors.red
+                      : Colors.lightGreen;
+              final double width = isFocused ? 2.0 : 1.0;
 
-            return OutlineInputBorder(borderSide: BorderSide(color: color, width: width));
-          }),
+              return OutlineInputBorder(
+                borderSide: BorderSide(color: color, width: width),
+              );
+            },
+          ),
         ),
-        textSelectionTheme: TextSelectionThemeData(
+        textSelectionTheme: const TextSelectionThemeData(
           cursorColor: Colors.lightGreen,
           selectionColor: Colors.lime,
           selectionHandleColor: Colors.lightGreen,
         ),
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -67,11 +80,13 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
+      children: const <Widget>[
         TextField(
           decoration: InputDecoration(
             hintText: 'enabled',

--- a/workshop/06_screens/instructions.md
+++ b/workshop/06_screens/instructions.md
@@ -72,10 +72,11 @@ Remember the `MaterialStateColor` class from previous workshop step? The one tha
 
 ```dart
 AppBarTheme(
-  backgroundColor: MaterialStateColor.resolveWith((states) =>
-    states.contains(MaterialState.scrolledUnder)
-      ? Colors.limeAccent
-      : Colors.lime
+  backgroundColor: MaterialStateColor.resolveWith(
+    (Set<MaterialState> states) =>
+        states.contains(MaterialState.scrolledUnder)
+            ? Colors.limeAccent
+            : Colors.lime,
   ),
 )
 ```

--- a/workshop/06_screens/snippet.dart
+++ b/workshop/06_screens/snippet.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -18,20 +18,27 @@ class ExampleApp extends StatelessWidget {
         ),
         // TODO 2: Provide appBarTheme field value
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -42,13 +49,20 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    final screenHeight = MediaQuery.of(context).size.height;
+    final double screenHeight = MediaQuery.of(context).size.height;
 
     return ListView.builder(
-      itemBuilder: (context, index) => Padding(
-        padding: EdgeInsets.all(20.0) + EdgeInsets.only(left: index.isEven ? 0.0 : 40.0, right: !index.isEven ? 0.0 : 40.0),
+      itemBuilder: (BuildContext context, int index) => Padding(
+        padding: const EdgeInsets.all(20.0).add(
+          EdgeInsets.only(
+            left: index.isEven ? 0.0 : 40.0,
+            right: !index.isEven ? 0.0 : 40.0,
+          ),
+        ),
         child: Container(height: screenHeight / 3, color: Colors.lime),
       ),
       itemCount: 4,

--- a/workshop/06_screens/solution.dart
+++ b/workshop/06_screens/solution.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -17,31 +17,39 @@ class ExampleApp extends StatelessWidget {
           background: Colors.green[50],
         ),
         appBarTheme: AppBarTheme(
-          backgroundColor: MaterialStateColor.resolveWith((states) =>
-            states.contains(MaterialState.scrolledUnder)
-              ? Colors.limeAccent
-              : Colors.lime
+          backgroundColor: MaterialStateColor.resolveWith(
+            (Set<MaterialState> states) =>
+                states.contains(MaterialState.scrolledUnder)
+                    ? Colors.limeAccent
+                    : Colors.lime,
           ),
           foregroundColor: Colors.blue,
           elevation: 8.0,
-          actionsIconTheme: IconThemeData(color: Colors.blue),
+          actionsIconTheme: const IconThemeData(color: Colors.blue),
           centerTitle: false,
         ),
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -52,13 +60,20 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
-    final screenHeight = MediaQuery.of(context).size.height;
+    final double screenHeight = MediaQuery.of(context).size.height;
 
     return ListView.builder(
-      itemBuilder: (context, index) => Padding(
-        padding: EdgeInsets.all(20.0) + EdgeInsets.only(left: index.isEven ? 0.0 : 40.0, right: !index.isEven ? 0.0 : 40.0),
+      itemBuilder: (BuildContext context, int index) => Padding(
+        padding: const EdgeInsets.all(20.0).add(
+          EdgeInsets.only(
+            left: index.isEven ? 0.0 : 40.0,
+            right: !index.isEven ? 0.0 : 40.0,
+          ),
+        ),
         child: Container(height: screenHeight / 3, color: Colors.lime),
       ),
       itemCount: 4,

--- a/workshop/07_conclusion/instructions.md
+++ b/workshop/07_conclusion/instructions.md
@@ -20,4 +20,4 @@ Good luck in mastering Flutter!
 
 > If you are interested in creating DartPad workshops, check the [*Workshop Authoring Guide*](https://github.com/dart-lang/dart-pad/wiki/Workshop-Authoring-Guide).
 >
->Source code for this workshop can be found in [*flutter_theme_workshop GitHub repository*](https://github.com/foxanna/flutter_theme_workshop).
+> Source code for this workshop can be found in [*flutter_theme_workshop GitHub repository*](https://github.com/foxanna/flutter_theme_workshop).

--- a/workshop/07_conclusion/snippet.dart
+++ b/workshop/07_conclusion/snippet.dart
@@ -1,12 +1,12 @@
-// ignore_for_file: prefer_const_constructors, prefer_const_literals_to_create_immutables, curly_braces_in_flow_control_structures
-
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(ExampleApp());
+  runApp(const ExampleApp());
 }
 
 class ExampleApp extends StatelessWidget {
+  const ExampleApp({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -14,20 +14,27 @@ class ExampleApp extends StatelessWidget {
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
       ),
-      home: ExamplePage(),
+      home: const ExamplePage(),
     );
   }
 }
 
 class ExamplePage extends StatelessWidget {
+  const ExamplePage({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Consistent design with Flutter Theme'),
-        actions: [IconButton(icon: Icon(Icons.account_circle), onPressed: () {})],
+        title: const Text('Consistent design with Flutter Theme'),
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.account_circle),
+            onPressed: () {},
+          ),
+        ],
       ),
-      body: Padding(
+      body: const Padding(
         padding: EdgeInsets.all(20.0),
         child: Center(
           child: ExampleWidget(),
@@ -38,14 +45,16 @@ class ExamplePage extends StatelessWidget {
 }
 
 class ExampleWidget extends StatelessWidget {
+  const ExampleWidget({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-      children: [
+      children: <Widget>[
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
-          children: [
+          children: <Widget>[
             Icon(
               Icons.account_circle,
               color: Theme.of(context).colorScheme.primary,
@@ -56,7 +65,7 @@ class ExampleWidget extends StatelessWidget {
             ),
           ],
         ),
-        TextField(
+        const TextField(
           decoration: InputDecoration(
             labelText: 'email',
             suffixIcon: Icon(Icons.email),
@@ -64,9 +73,9 @@ class ExampleWidget extends StatelessWidget {
         ),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            TextButton(child: Text('Skip'), onPressed: () {}),
-            ElevatedButton(child: Text('Register'), onPressed: () {}),
+          children: <Widget>[
+            TextButton(child: const Text('Skip'), onPressed: () {}),
+            ElevatedButton(child: const Text('Register'), onPressed: () {}),
           ],
         ),
       ],


### PR DESCRIPTION
Hi Anna,

Thanks for the great workshop! I found it very easy and fluent to complete the whole workshop, and the difficulty increases gradually, which is awesome! I've also learned more about the `MaterialState*` that used to exist without some proper explanations.

> Estimate total time to take the workshop: 40 minutes

Though I still have some questions and concerns, some of them are addressed in the PR, I'll tell others in the below description.

## Linter rules ignore

I saw all dart files are marked with multiple linter rules ignored, as I found they're unnecessary to ignore, I've removed most of them and filled codes with a proper format. Please let me know if you have some other opinion about it.

## Confusion in instructions

> In fact, under the hood, the `MaterialApp` widget passes the given theme value to the inner `Theme` widget, which wraps all application screens.

Given the fact of [the source code](https://github.com/flutter/flutter/blob/eb54cefb97fa5f712f80e3a2bdeb0baa6542c4eb/packages/flutter/lib/src/material/app.dart#L881), I don't think it actually _wraps all application screens_, but *wraps at the top of the application*. I've update the sentence in the change.

> Customize global `iconTheme`. The email and globe icons should become lime and half-transparent. The account icon in the top corner should become half-transparent.

I got a bit confused here since the account icon has its own requirement without `Colors.lime`, but I saw it still has a different color from other icons, which should be inherited from the `AppBarTheme`. I'm wondering if such inherit relation needs to tell users.

> However, describing all `TextStyle` fields of `TextTheme` is unnecessary.

It might be _typically unnecessary_, just a nit.

> and is not showing an error;

There are multiple short sentences with the same suffix here, which might be redundant.